### PR TITLE
Adding API-key for admintest

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -17,10 +17,12 @@ angular.module('app', [
 ]).config(function(RestangularProvider) {
 	RestangularProvider.setBaseUrl('https://api.tnyu.org/v2');
 
+	var ApiKey = prompt("Provide an API key please!");
 	// Configuring Restangular to work with JSONAPI spec
 	RestangularProvider.setDefaultHeaders({
 		'Accept': 'application/vnd.api+json, application/*, */*',
-		'Content-Type': 'application/vnd.api+json; ext=bulk'
+		'Content-Type': 'application/vnd.api+json; ext=bulk',
+		'x-api-key': ApiKey
 	});
 
 	RestangularProvider.addResponseInterceptor(function(data, operation, what, url, response, deferred) {

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,6 @@ deployment:
     branch: master
     commands:
       - turbolift -u $RAXUSER -a $RAXAPIKEY --os-rax-auth $RAXREGION upload -s $HOME/$CIRCLE_PROJECT_REPONAME/app -c $CONTAINER
-      - cd $HOME/$CIRCLE_PROJECT_REPONAME/app/js && touch app2.js && sed 's%https://api.tnyu.org/v2%https://api.tnyu.org/v2-test%g' app.js > app2.js && rm app.js && mv app2.js app.js && turbolift -u $RAXUSER -a $RAXAPIKEY --os-rax-auth $RAXREGION upload -s $HOME/$CIRCLE_PROJECT_REPONAME/app -c "intranet-test"
+      - cd $HOME/$CIRCLE_PROJECT_REPONAME/app/js && touch app2.js && sed 's%https://api.tnyu.org/v2%https://api.tnyu.org/v2-test%g' app.js > app2.js && rm app.js && mv app2.js app.js
+      - cd $HOME/$CIRCLE_PROJECT_REPONAME/app/js && touch app2.js && sed 's%var ApiKey = "";%var ApiKey = prompt("Provide an API key please!");%g' app.js > app2.js && rm app.js && mv app2.js app.js
+      - turbolift -u $RAXUSER -a $RAXAPIKEY --os-rax-auth $RAXREGION upload -s $HOME/$CIRCLE_PROJECT_REPONAME/app -c "intranet-test"


### PR DESCRIPTION
There exists a new service that's called `admintest.tnyu.org`. This doesn't have any `facebookId`s that exist in it or any real users. This means that we have to use an API key in order to boot it up. 

In this case - I am adding an ApiKey variable that's blank if it's not set. This is just a quick implementation - please suggest any changes if need be. I'm in an ethics class so I didn't get much time to think about this solution.

In a admintest environment it is replaced with `var ApiKey = prompt("Provide an API key please!");`. This is automatically done by CircleCI.

---

Make this solution better - please! Some debug mode or something we can establish for the `admintest`. I'm very certain there's a better method - this is just a very basic change.
