### PR TITLE
enable position page to populate via position id

### DIFF
--- a/app/js/controllers/actions/position/position-list-ctrl.js
+++ b/app/js/controllers/actions/position/position-list-ctrl.js
@@ -13,11 +13,14 @@ angular
 	Restangular.all(resourceName)
 	.getList()
 	.then(function(data) {	
+
+		$scope.data = data;
+
 		if (resourceId) {
 			var index = _.findIndex($scope.data, {id: resourceId});
 			$scope.model = $scope.data[index];
 		}	
-		$scope.data = data;
+		
 		_.each($scope.data, function(element) {
 			element.attributes.responsibilities = element.attributes.responsibilities.length == 0 ? "None" : element.attributes.responsibilities.join(' ')
 			element.attributes.name = preProcess.positionToString(teamsIdToName, element, true);


### PR DESCRIPTION
**Problem**
line 20 `var index = _.findIndex($scope.data, {id: resourceId});` returns `-1` since `$scope.data` was not defined yet. now when we go to `r/positions/list/561b06e2b3448ead9acb4086` the page populates the correct data.