### PR TITLE
Converted status field to Submit/Save buttons

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -48,6 +48,7 @@
   <script src="/js/controllers/actions/default/default-add-ctrl.js"></script>
   <script src="/js/controllers/actions/event/event-add-ctrl.js"></script>
   <script src="/js/controllers/actions/event/event-list-ctrl.js"></script>
+  <script src="/js/controllers/actions/event/event-edit-ctrl.js"></script>
   <script src="/js/controllers/actions/membership/membership-add-ctrl.js"></script>
   <script src="/js/controllers/actions/membership/membership-list-ctrl.js"></script>
   <script src="/js/controllers/actions/membership/membership-edit-ctrl.js"></script>

--- a/app/js/controllers/actions/event/event-add-ctrl.js
+++ b/app/js/controllers/actions/event/event-add-ctrl.js
@@ -26,7 +26,7 @@ angular
 	});
 
 	$scope.createResource = function (model, rdesc, statusOption) {
-		if(statusFound){
+		if($scope.statusFound){
 			model.attributes.status = statusOption;
 		}
 		else{

--- a/app/js/controllers/actions/event/event-add-ctrl.js
+++ b/app/js/controllers/actions/event/event-add-ctrl.js
@@ -25,12 +25,6 @@ angular
 		$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
 	});
 
-	$scope.createResourceTest = function(model, rdesc, statusField){
-		dataTransformer.createResource(model, rdesc, resource).then(function(data) {
-			$state.go('list', {resourceName: resourceName, selectionMode: 'single', id: data.id});
-		})
-	}
-
 	$scope.createResource = function (model, rdesc, statusOption) {
 		if(statusFound){
 			model.attributes.status = statusOption;

--- a/app/js/controllers/actions/event/event-add-ctrl.js
+++ b/app/js/controllers/actions/event/event-add-ctrl.js
@@ -19,19 +19,10 @@ angular
 		$scope.rdesc = apiDescription.resource(resourceName);
 		//In case status field is not found
 		if($scope.rdesc.attributes.fields[18].name == "status"){
-			$scope.statusField = $scope.rdesc.attributes.fields[18];
 			$scope.statusFound = true;
 		}
-		//Need to make two rdsec so status data is properly created.
-		$scope.rdescWithoutStatus = $scope.rdesc;
-		$scope.rdescWithoutStatus.attributes.fields = $scope.rdesc.attributes.fields.filter((element) => {return element.name != "status";})
-	//If not found, the page will load with the default field and submit button
-		if($scope.statusFound){
-			$scope.data = dataTransformer.loadLinkedData($scope.rdescWithoutStatus, $scope.refreshData);
-		}
-		else{
-			$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
-		}
+
+		$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
 	});
 
 	$scope.createResourceTest = function(model, rdesc, statusField){
@@ -40,14 +31,12 @@ angular
 		})
 	}
 
-	$scope.createResource = function (model, rdesc, status) {
+	$scope.createResource = function (model, rdesc, statusOption) {
 		if(statusFound){
-			if(status == 0){
-				model.attributes.status = "draft";
-			}
-			else if(status == 1){
-				model.attributes.status = "announced";
-			}
+			model.attributes.status = statusOption;
+		}
+		else{
+			model.attributes.status = "draft";
 		}
 		dataTransformer.createResource(model, rdesc, resource).then(function(data) {
 			$state.go('list', {resourceName: resourceName, selectionMode: 'single', id: data.id});

--- a/app/js/controllers/actions/event/event-add-ctrl.js
+++ b/app/js/controllers/actions/event/event-add-ctrl.js
@@ -6,21 +6,49 @@ angular
 		$interval, Restangular, apiDescriptor, formElementProvider, dataTransformer) {
 
 	var resourceName = $stateParams.resourceName;
-
 	var resource = Restangular.all(resourceName);
 
 	$scope.fep = formElementProvider;
 
 	$scope.data = {};
 	$scope.model = {attributes: {}};
+	//boolean used for html
+	$scope.statusFound = false;
 
 	apiDescriptor.then(function(apiDescription) {
 		$scope.rdesc = apiDescription.resource(resourceName);
-		$scope.fieldOne = $scope.rdesc.attributes.fields[0];
-		$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
+		//In case status field is not found
+		if($scope.rdesc.attributes.fields[18].name == "status"){
+			$scope.statusField = $scope.rdesc.attributes.fields[18];
+			$scope.statusFound = true;
+		}
+		//Need to make two rdsec so status data is properly created.
+		$scope.rdescWithoutStatus = $scope.rdesc;
+		$scope.rdescWithoutStatus.attributes.fields = $scope.rdesc.attributes.fields.filter((element) => {return element.name != "status";})
+	//If not found, the page will load with the default field and submit button
+		if($scope.statusFound){
+			$scope.data = dataTransformer.loadLinkedData($scope.rdescWithoutStatus, $scope.refreshData);
+		}
+		else{
+			$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
+		}
 	});
 
-	$scope.createResource = function (model, rdesc) {
+	$scope.createResourceTest = function(model, rdesc, statusField){
+		dataTransformer.createResource(model, rdesc, resource).then(function(data) {
+			$state.go('list', {resourceName: resourceName, selectionMode: 'single', id: data.id});
+		})
+	}
+
+	$scope.createResource = function (model, rdesc, status) {
+		if(statusFound){
+			if(status == 0){
+				model.attributes.status = "draft";
+			}
+			else if(status == 1){
+				model.attributes.status = "announced";
+			}
+		}
 		dataTransformer.createResource(model, rdesc, resource).then(function(data) {
 			$state.go('list', {resourceName: resourceName, selectionMode: 'single', id: data.id});
 		})

--- a/app/js/controllers/actions/event/event-edit-ctrl.js
+++ b/app/js/controllers/actions/event/event-edit-ctrl.js
@@ -21,16 +21,7 @@ angular
 			$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
 			
 			if($scope.rdesc.attributes.fields[18].name == "status"){
-				$scope.statusField = $scope.rdesc.attributes.fields[18];
 				$scope.statusFound = true;
-			}
-			$scope.rdescWithoutStatus = $scope.rdesc;
-			$scope.rdescWithoutStatus.attributes.fields = $scope.rdesc.attributes.fields.filter((element) => {return element.name != "status";})
-			if($scope.statusFound){
-				$scope.data = dataTransformer.loadLinkedData($scope.rdescWithoutStatus, $scope.refreshData);
-			}
-			else{
-				$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
 			}
 		});
 		$scope.model = dataTransformer.delink(data);
@@ -38,7 +29,7 @@ angular
 	});
 
 	$scope.updateResource = function (model, rdesc, statusData) {
-		if(statusData != 0){
+		if(statusFound !=0){
 			model.attributes.status = statusData;
 		}
 		dataTransformer.updateResource(model, rdesc, resource).then(function (data) {

--- a/app/js/controllers/actions/event/event-edit-ctrl.js
+++ b/app/js/controllers/actions/event/event-edit-ctrl.js
@@ -11,17 +11,23 @@ angular
 	var resource = Restangular.one(resourceName, resourceId);
 
 	$scope.fep = formElementProvider;
+	$scope.statusFound = false;
 
 	$scope.data = {};
 	resource.get().then(function(data) {
 		apiDescriptor.then(function(apiDescription) {
 			$scope.rdesc = apiDescription.resource(resourceName);
 			$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
+			$scope.statusFound = true;
 		});
 		$scope.model = dataTransformer.delink(data);
+		$scope.statusData = $scope.model.attributes.status;
 	});
 
-	$scope.updateResource = function (model, rdesc) {
+	$scope.updateResource = function (model, rdesc, updatedStatus) {
+		if(updatedStatus != undefined){
+			model.attributes.status = updatedStatus;
+		}
 		dataTransformer.updateResource(model, rdesc, resource).then(function (data) {
 			$state.go('list', {resourceName: resourceName, selectionMode: 'single', id: data.id})
 		});

--- a/app/js/controllers/actions/event/event-edit-ctrl.js
+++ b/app/js/controllers/actions/event/event-edit-ctrl.js
@@ -1,0 +1,52 @@
+'use strict';
+
+angular
+.module('app.controllers')
+.controller('EventEditCtrl', function($scope, $rootScope, $stateParams, $state,
+		$interval, Restangular, apiDescriptor, formElementProvider, dataTransformer) {
+
+	var resourceName = $stateParams.resourceName;
+	var resourceId = $stateParams.id;
+	var resource = Restangular.one(resourceName, resourceId);
+
+	$scope.fep = formElementProvider;
+
+	$scope.data = {};
+	$scope.statusFound = false;
+	
+
+	resource.get().then(function(data) {
+		apiDescriptor.then(function(apiDescription) {
+			$scope.rdesc = apiDescription.resource(resourceName);
+			$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
+			
+			if($scope.rdesc.attributes.fields[18].name == "status"){
+				$scope.statusField = $scope.rdesc.attributes.fields[18];
+				$scope.statusFound = true;
+			}
+			$scope.rdescWithoutStatus = $scope.rdesc;
+			$scope.rdescWithoutStatus.attributes.fields = $scope.rdesc.attributes.fields.filter((element) => {return element.name != "status";})
+			if($scope.statusFound){
+				$scope.data = dataTransformer.loadLinkedData($scope.rdescWithoutStatus, $scope.refreshData);
+			}
+			else{
+				$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
+			}
+		});
+		$scope.model = dataTransformer.delink(data);
+		$scope.statusData = $scope.model.attributes.status;
+	});
+
+	$scope.updateResource = function (model, rdesc, statusData) {
+		if(statusData != 0){
+			model.attributes.status = statusData;
+		}
+		dataTransformer.updateResource(model, rdesc, resource).then(function (data) {
+			$state.go('list', {resourceName: resourceName, selectionMode: 'single', id: data.id})
+		});
+	}
+
+	$scope.refreshData = function(data, fieldResourceType) {
+		data[fieldResourceType] = Restangular.all(fieldResourceType).getList().$object;
+	};
+});

--- a/app/js/controllers/actions/event/event-edit-ctrl.js
+++ b/app/js/controllers/actions/event/event-edit-ctrl.js
@@ -7,31 +7,21 @@ angular
 
 	var resourceName = $stateParams.resourceName;
 	var resourceId = $stateParams.id;
+
 	var resource = Restangular.one(resourceName, resourceId);
 
 	$scope.fep = formElementProvider;
 
 	$scope.data = {};
-	$scope.statusFound = false;
-	
-
 	resource.get().then(function(data) {
 		apiDescriptor.then(function(apiDescription) {
 			$scope.rdesc = apiDescription.resource(resourceName);
 			$scope.data = dataTransformer.loadLinkedData($scope.rdesc, $scope.refreshData);
-			
-			if($scope.rdesc.attributes.fields[18].name == "status"){
-				$scope.statusFound = true;
-			}
 		});
 		$scope.model = dataTransformer.delink(data);
-		$scope.statusData = $scope.model.attributes.status;
 	});
 
-	$scope.updateResource = function (model, rdesc, statusData) {
-		if(statusFound !=0){
-			model.attributes.status = statusData;
-		}
+	$scope.updateResource = function (model, rdesc) {
 		dataTransformer.updateResource(model, rdesc, resource).then(function (data) {
 			$state.go('list', {resourceName: resourceName, selectionMode: 'single', id: data.id})
 		});

--- a/app/js/services/page-provider.js
+++ b/app/js/services/page-provider.js
@@ -8,6 +8,7 @@ angular.module('app.services')
 			'list': 'partials/actions/default/default-list.html'
 		},
 		'events': {
+			'edit': 'partials/actions/event/event-edit.html',
 			'add': 'partials/actions/event/event-add.html',
 			'list': 'partials/actions/event/event-list.html'
 		},

--- a/app/js/services/page-provider.js
+++ b/app/js/services/page-provider.js
@@ -8,7 +8,7 @@ angular.module('app.services')
 			'list': 'partials/actions/default/default-list.html'
 		},
 		'events': {
-			'edit': 'partials/actions/event/event-edit.html',
+			//'edit': 'partials/actions/event/event-edit.html',
 			'add': 'partials/actions/event/event-add.html',
 			'list': 'partials/actions/event/event-list.html'
 		},

--- a/app/js/services/page-provider.js
+++ b/app/js/services/page-provider.js
@@ -8,7 +8,7 @@ angular.module('app.services')
 			'list': 'partials/actions/default/default-list.html'
 		},
 		'events': {
-			//'edit': 'partials/actions/event/event-edit.html',
+			'edit': 'partials/actions/event/event-edit.html',
 			'add': 'partials/actions/event/event-add.html',
 			'list': 'partials/actions/event/event-list.html'
 		},

--- a/app/partials/actions/event/event-add.html
+++ b/app/partials/actions/event/event-add.html
@@ -20,7 +20,7 @@
 
 	<div class="form-group" ng-if="statusFound">
 		<button class="btn btn-primary" ng-click="createResource(model, rdesc, 'announced')">Announce Event</button>
-		<button class="btn btn-info" ng-click="createResource(model, rdesc, 'draft')">Draft</button>
+		<button class="btn btn-info" ng-click="createResource(model, rdesc, 'draft')">Save as Draft</button>
 	</div>
 	<div class="form-group" ng-if="!statusFound">
 			<button class="btn btn-primary" ng-click="createResource(model, rdesc, 'draft')">Submit</button>

--- a/app/partials/actions/event/event-add.html
+++ b/app/partials/actions/event/event-add.html
@@ -19,10 +19,10 @@
 	</div>
 
 	<div class="form-group" ng-if="statusFound">
-		<button class="btn btn-primary" ng-click="createResource(model, rdesc, 1)">Announce Event</button>
-		<button class="btn btn-info" ng-click="createResource(model, rdesc, 0)">Draft</button>
+		<button class="btn btn-primary" ng-click="createResource(model, rdesc, 'announced')">Announce Event</button>
+		<button class="btn btn-info" ng-click="createResource(model, rdesc, 'draft')">Draft</button>
 	</div>
 	<div class="form-group" ng-if="!statusFound">
-			<button class="btn btn-primary" ng-click="createResource(model, rdesc, 0)">Submit</button>
+			<button class="btn btn-primary" ng-click="createResource(model, rdesc, 'draft')">Submit</button>
 		</div>
 </div>

--- a/app/partials/actions/event/event-add.html
+++ b/app/partials/actions/event/event-add.html
@@ -18,7 +18,11 @@
 		ng-include="'/partials/fields/default-field.html'">
 	</div>
 
-	<div class="form-group">
-		<button class="btn btn-primary" ng-click="createResource(model, rdesc)">Create</button>
+	<div class="form-group" ng-if="statusFound">
+		<button class="btn btn-primary" ng-click="createResource(model, rdesc, 1)">Announce Event</button>
+		<button class="btn btn-info" ng-click="createResource(model, rdesc, 0)">Draft</button>
 	</div>
+	<div class="form-group" ng-if="!statusFound">
+			<button class="btn btn-primary" ng-click="createResource(model, rdesc, 0)">Submit</button>
+		</div>
 </div>

--- a/app/partials/actions/event/event-edit.html
+++ b/app/partials/actions/event/event-edit.html
@@ -13,17 +13,17 @@
 	</form
 	>
 	<div class="form-group" ng-if="statusFound">
-		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,undefined)">Save Changes</button>
+		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,undefined)">Save Changes as {{statusData}} event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='draft'">
-			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'announced')">Announce this Event</button>
+			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'announced')">Save and Announce this Event</button>
 			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'draft')">Delete Event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='announced'">
-			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'canceled')">Cancel this Event</button>
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'canceled')">Save and Cancel this Event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='canceled'">
-			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'announced')">Un-Cancel this Event</button>
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'announced')">Save and Un-Cancel this Event</button>
 	</div>
 	<div class="form-group" ng-if="!statusFound">
 		<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'draft')">Submit</button>

--- a/app/partials/actions/event/event-edit.html
+++ b/app/partials/actions/event/event-edit.html
@@ -13,7 +13,7 @@
 	</form
 	>
 	<div class="form-group" ng-if="statusFound">
-		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,0)">Save Changes</button>
+		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,undefined)">Save Changes</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='draft'">
 			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'draft')">Announce this Event</button>

--- a/app/partials/actions/event/event-edit.html
+++ b/app/partials/actions/event/event-edit.html
@@ -16,7 +16,7 @@
 		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,undefined)">Save Changes as {{statusData}} event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='draft'">
-			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'announced')">Save and Announce this Event</button>
+			<button class="btn btn-success" ng-click="updateResource(model, rdesc, 'announced')">Save and Announce this Event</button>
 			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'draft')">Delete Event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='announced'">

--- a/app/partials/actions/event/event-edit.html
+++ b/app/partials/actions/event/event-edit.html
@@ -1,0 +1,31 @@
+<div class="container" ng-controller="EventEditCtrl">
+	<h3>
+		Edit {{rdesc.attributes.name.singular}}
+	</h3>
+	<h5>{{rdesc.attributes.description}}</h5>
+
+	<form name="form" novalidate>
+		<div class="form-group"
+			ng-repeat="field in rdesc.attributes.fields"
+			ng-if="fep.hiddenFields.indexOf(field.name) == -1"
+			ng-include="'/partials/fields/default-field.html'">
+		</div>
+	</form
+	>
+	<div class="form-group" ng-if="statusFound">
+		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,0)">Save Changes</button>
+	</div>
+	<div class="form-group" ng-if="statusData=='draft'">
+			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, draft)">Announce this Event</button>
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, draft)">Delete Event</button>
+	</div>
+	<div class="form-group" ng-if="statusData=='announced'">
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, canceled)">Cancel this Event</button>
+	</div>
+	<div class="form-group" ng-if="statusData=='canceled'">
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, announced)">Un-Cancel this Event</button>
+	</div>
+	<div class="form-group" ng-if="!statusFound">
+		<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 0)">Submit</button>
+	</div>
+</div>

--- a/app/partials/actions/event/event-edit.html
+++ b/app/partials/actions/event/event-edit.html
@@ -16,16 +16,16 @@
 		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,0)">Save Changes</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='draft'">
-			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, draft)">Announce this Event</button>
-			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, draft)">Delete Event</button>
+			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'draft')">Announce this Event</button>
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'draft')">Delete Event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='announced'">
-			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, canceled)">Cancel this Event</button>
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'canceled')">Cancel this Event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='canceled'">
-			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, announced)">Un-Cancel this Event</button>
+			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'announced')">Un-Cancel this Event</button>
 	</div>
 	<div class="form-group" ng-if="!statusFound">
-		<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 0)">Submit</button>
+		<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'draft')">Submit</button>
 	</div>
 </div>

--- a/app/partials/actions/event/event-edit.html
+++ b/app/partials/actions/event/event-edit.html
@@ -16,7 +16,7 @@
 		<button class="btn btn-primary" ng-click="updateResource(model, rdesc,undefined)">Save Changes</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='draft'">
-			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'draft')">Announce this Event</button>
+			<button class="btn btn-primary" ng-click="updateResource(model, rdesc, 'announced')">Announce this Event</button>
 			<button class="btn btn-danger" ng-click="updateResource(model, rdesc, 'draft')">Delete Event</button>
 	</div>
 	<div class="form-group" ng-if="statusData=='announced'">


### PR DESCRIPTION
For Issue #166 
* Removed status field from add and edit view. They would only appear if the status field was not found, which also means the view will use the original submit/save buttons.
* List view should still include status field; they should be updated as well
* Editing Draft events: Options to announce, and save changes will appear
* Editing Announced events: Options to cancel the event will appear
* Editing Canceled events: Options to un-cancel and delete events will appear
* Did basic QA testing of adding/editing events with different status.

Small bug: When updating add and edited resources, users have to refresh the list view to see the updates.